### PR TITLE
Change TouchTask and DateSelector to use seconds

### DIFF
--- a/source/appendixes/coretasks.xml
+++ b/source/appendixes/coretasks.xml
@@ -4563,7 +4563,7 @@ file defines a task in the format: name=path.to.Task -->
                         <entry><literal>millis</literal></entry>
                         <entry><literal role="type">Integer</literal></entry>
                         <entry>The number of milliseconds since Midnight Jan 1 1970 (Unix
-                            epoch). (Deprecated, use seconds instead.)</entry>
+                            epoch).</entry>
                         <entry><literal>now</literal></entry>
                         <entry>No</entry>
                     </row>

--- a/source/appendixes/coretasks.xml
+++ b/source/appendixes/coretasks.xml
@@ -4553,10 +4553,17 @@ file defines a task in the format: name=path.to.Task -->
                         <entry>No</entry>
                     </row>
                     <row>
+                        <entry><literal>seconds</literal></entry>
+                        <entry><literal role="type">Integer</literal></entry>
+                        <entry>The number of seconds since Midnight Jan 1 1970 (Unix epoch).</entry>
+                        <entry><literal>now</literal></entry>
+                        <entry>No</entry>
+                    </row>
+                    <row>
                         <entry><literal>millis</literal></entry>
                         <entry><literal role="type">Integer</literal></entry>
                         <entry>The number of milliseconds since Midnight Jan 1 1970 (Unix
-                            epoche).</entry>
+                            epoch). (Deprecated, use seconds instead.)</entry>
                         <entry><literal>now</literal></entry>
                         <entry>No</entry>
                     </row>

--- a/source/appendixes/selectors.xml
+++ b/source/appendixes/selectors.xml
@@ -190,27 +190,35 @@
                     </row>
                     <row>
                         <entry><literal>seconds</literal></entry>
-                        <entry>The number of seconds since 1970 that should be tested for.</entry>
+                        <entry>The number of seconds since Midnight Jan 1 1970 (Unix epoch) that should be
+                            tested for.</entry>
                         <entry>n/a</entry>
                     </row>
                     <row>
                         <entry><literal>when</literal></entry>
                         <entry>Indicates how to interpret the date, whether the files to be selected
                             are those whose last modified times should be before, after, or equal to
-                            the specified value. Accepted values are: <literal>before</literal> -
-                            select files whose last modified date is before the indicated date
+                            the specified value. Accepted values are:
+                            <itemizedlist><listitem><para>
+                                <literal>before</literal> - select files whose last modified date is
+                                    before the indicated date
+                            </para></listitem></itemizedlist>
+                            <itemizedlist><listitem><para>
                                 <literal>after</literal> - select files whose last modified date is
-                            after the indicated date <literal>equal</literal> - select files whose
-                            last modified date is this exact date </entry>
+                                    after the indicated date
+                            </para></listitem></itemizedlist>
+                            <itemizedlist><listitem><para>
+                                <literal>equal</literal> - select files whose last modified date is
+                                    this exact date
+                            </para></listitem></itemizedlist>
+                        </entry>
                         <entry>equal</entry>
                         <entry>No</entry>
                     </row>
                     <row>
                         <entry><literal>granularity</literal></entry>
-                        <entry>The number of milliseconds leeway to use when comparing file
-                            modification times. This is needed because not every file system
-                            supports tracking the last modified time to the millisecond
-                            level.</entry>
+                        <entry>The number of seconds leeway to use when comparing file
+                            modification times.</entry>
                         <entry>0</entry>
                         <entry>No</entry>
                     </row>

--- a/source/appendixes/selectors.xml
+++ b/source/appendixes/selectors.xml
@@ -195,6 +195,12 @@
                         <entry>n/a</entry>
                     </row>
                     <row>
+                        <entry><literal>millis</literal></entry>
+                        <entry>The number of milliseconds since Midnight Jan 1 1970 (Unix epoch) that should be
+                            tested for. Note: It will be internaly converted to seconds.</entry>
+                        <entry>n/a</entry>
+                    </row>
+                    <row>
                         <entry><literal>when</literal></entry>
                         <entry>Indicates how to interpret the date, whether the files to be selected
                             are those whose last modified times should be before, after, or equal to


### PR DESCRIPTION
Fixes: phingofficial#1449

Changed code for TouchTask and DateSelector to be based on seconds
instead of milliseconds.