### PR TITLE
Added `failonerror` to the `ReplaceRegexpTask`

### DIFF
--- a/source/appendixes/coretasks/ReplaceRegexpTask.xml
+++ b/source/appendixes/coretasks/ReplaceRegexpTask.xml
@@ -71,6 +71,17 @@
                     <entry>n/a</entry>
                     <entry>Yes</entry>
                 </row>
+                <row>
+                    <entry>
+                        <literal>failonerror</literal>
+                    </entry>
+                    <entry>
+                        <literal role="type">Boolean</literal>
+                    </entry>
+                    <entry>If set to true, the task will fail on error</entry>
+                    <entry><literal>false</literal></entry>
+                    <entry>No</entry>
+                </row>
             </tbody>
         </tgroup>
     </table>


### PR DESCRIPTION
Related to https://github.com/phingofficial/phing/pull/1866

Added `failonerror` to the `ReplaceRegexpTask` documentation.
